### PR TITLE
Add DBAL 4 support alongside DBAL 3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,11 @@
   },
   "require": {
     "moneyphp/money": "^3.0|^4.0",
-    "doctrine/dbal": "^2.8|^3.0",
+    "doctrine/dbal": "^3.6|^4.0",
     "php": "^8.4",
-    "ramsey/uuid-doctrine": "^1.4"
+    "ramsey/uuid-doctrine": "^1.4|^2.0"
   },
   "require-dev": {
-    "doctrine/cache": "~1.0",
-    "doctrine/annotations": "~1.0",
     "symfony/framework-bundle": "^7.0",
     "symfony/yaml": "^7.0",
     "assoconnect/php-quality-config": "^2.2"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,5 +3,16 @@ parameters:
         - src/
         - tests/
 
+    # The errors below depend on which DBAL major is installed (^3.6|^4.0 are both supported),
+    # so each analysis run only matches half of them.
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        # DBAL 3 only: static factories removed in DBAL 4
+        - '#Call to an undefined static method Doctrine\\DBAL\\Types\\ConversionException::conversionFailed(Format|InvalidType)\(\)\.#'
+        # DBAL 4 only: exception classes absent from DBAL 3
+        - '#unknown class Doctrine\\DBAL\\Types\\Exception\\Invalid(Format|Type)#'
+        # Removed from the base Type class in DBAL 4 but still defined by our types for DBAL 3
+        - '#Call to an undefined method Doctrine\\DBAL\\Types\\Type::requiresSQLCommentHint\(\)\.#'
+
 includes:
     - vendor/assoconnect/php-quality-config/phpstan.extension.neon

--- a/src/Doctrine/DBAL/Types/AbstractFixedLengthStringType.php
+++ b/src/Doctrine/DBAL/Types/AbstractFixedLengthStringType.php
@@ -15,7 +15,7 @@ abstract class AbstractFixedLengthStringType extends Type
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         $fieldDeclaration['length'] = $this->getLength();
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        return $platform->getStringTypeDeclarationSQL($fieldDeclaration);
     }
 
     abstract protected function getLength(): int;

--- a/src/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsType.php
+++ b/src/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsType.php
@@ -8,11 +8,15 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
+use Doctrine\DBAL\Types\Exception\InvalidType;
 use Doctrine\DBAL\Types\Type;
 
 class DateTimeImmutableMicroSecondsType extends Type
 {
     public const NAME = 'datetime_immutable_micro_seconds';
+
+    private const FORMAT = 'Y-m-d H:i:s.v';
 
     public function getName(): string
     {
@@ -30,18 +34,13 @@ class DateTimeImmutableMicroSecondsType extends Type
             return $value;
         }
 
-        $date = DateTimeImmutable::createFromFormat('Y-m-d H:i:s.v', $value);
+        $date = DateTimeImmutable::createFromFormat(self::FORMAT, $value);
 
         if ($date === false) {
             try {
                 $dateTime = new DateTimeImmutable($value);
             } catch (\Exception $e) {
-                throw ConversionException::conversionFailedFormat(
-                    $value,
-                    $this->getName(),
-                    'Y-m-d H:i:s.v',
-                    $e // Previous exception bundled
-                );
+                throw $this->createInvalidFormatException($value, $e);
             }
             return $dateTime;
         }
@@ -56,13 +55,34 @@ class DateTimeImmutableMicroSecondsType extends Type
         }
 
         if ($value instanceof DateTimeImmutable) {
-            return $value->format('Y-m-d H:i:s.v');
+            return $value->format(self::FORMAT);
         }
 
-        throw ConversionException::conversionFailedInvalidType(
-            $value,
-            $this->getName(),
-            ['null', DateTimeImmutable::class]
-        );
+        throw $this->createInvalidTypeException($value);
+    }
+
+    /**
+     * DBAL 4 replaced the ConversionException static factories with dedicated exception classes.
+     * The runtime conditionals below can be inlined once DBAL 3 support is dropped.
+     */
+    private function createInvalidFormatException(mixed $value, \Throwable $previous): ConversionException
+    {
+        if (class_exists(InvalidFormat::class)) {
+            return InvalidFormat::new($value, self::NAME, self::FORMAT, $previous);
+        }
+
+        return ConversionException::conversionFailedFormat($value, self::NAME, self::FORMAT, $previous);
+    }
+
+    private function createInvalidTypeException(mixed $value): ConversionException
+    {
+        if (class_exists(InvalidType::class)) {
+            return InvalidType::new($value, self::NAME, ['null', DateTimeImmutable::class]);
+        }
+
+        return ConversionException::conversionFailedInvalidType($value, self::NAME, [
+            'null',
+            DateTimeImmutable::class,
+        ]);
     }
 }

--- a/src/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsType.php
+++ b/src/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsType.php
@@ -64,6 +64,9 @@ class DateTimeImmutableMicroSecondsType extends Type
     /**
      * DBAL 4 replaced the ConversionException static factories with dedicated exception classes.
      * The runtime conditionals below can be inlined once DBAL 3 support is dropped.
+     * Excluded from coverage: only one branch can run for a given installed DBAL major.
+     *
+     * @codeCoverageIgnore
      */
     private function createInvalidFormatException(mixed $value, \Throwable $previous): ConversionException
     {
@@ -74,6 +77,9 @@ class DateTimeImmutableMicroSecondsType extends Type
         return ConversionException::conversionFailedFormat($value, self::NAME, self::FORMAT, $previous);
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function createInvalidTypeException(mixed $value): ConversionException
     {
         if (class_exists(InvalidType::class)) {

--- a/tests/Doctrine/DBAL/Types/BelgianEnterpriseNumberTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/BelgianEnterpriseNumberTypeTest.php
@@ -6,6 +6,7 @@ namespace AssoConnect\DoctrineTypesBundle\Tests\Doctrine\DBAL\Types;
 
 use AssoConnect\DoctrineTypesBundle\Doctrine\DBAL\Types\BelgianEnterpriseNumberType;
 use AssoConnect\DoctrineTypesBundle\Tests\TypeTestCase;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class BelgianEnterpriseNumberTypeTest extends TypeTestCase
 {
@@ -16,16 +17,18 @@ class BelgianEnterpriseNumberTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(BelgianEnterpriseNumberType::NAME, $this->type->getName());
+        self::assertSame(BelgianEnterpriseNumberType::NAME, (new BelgianEnterpriseNumberType())->getName());
     }
 
     public function testGetSQLDeclaration(): void
     {
-        $this->abstractPlatform
-            ->method('getVarcharTypeDeclarationSQL')
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform
+            ->expects(self::once())
+            ->method('getStringTypeDeclarationSQL')
             ->with(['length' => BelgianEnterpriseNumberType::LENGTH])
             ->willReturn('VARCHAR');
 
-        self::assertSame('VARCHAR', $this->type->getSQLDeclaration([], $this->abstractPlatform));
+        self::assertSame('VARCHAR', $this->type->getSQLDeclaration([], $platform));
     }
 }

--- a/tests/Doctrine/DBAL/Types/BicTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/BicTypeTest.php
@@ -16,12 +16,12 @@ class BicTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(BicType::NAME, $this->type->getName());
+        self::assertSame(BicType::NAME, (new BicType())->getName());
     }
 
     public function testGetSQLDeclaration(): void
     {
-        $this->abstractPlatform->method('getVarcharTypeDeclarationSQL')->willReturn('VARCHAR');
+        $this->abstractPlatform->method('getStringTypeDeclarationSQL')->willReturn('VARCHAR');
         self::assertSame('VARCHAR', $this->type->getSQLDeclaration([], $this->abstractPlatform));
     }
 }

--- a/tests/Doctrine/DBAL/Types/CountryTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/CountryTypeTest.php
@@ -6,6 +6,7 @@ namespace AssoConnect\DoctrineTypesBundle\Tests\Doctrine\DBAL\Types;
 
 use AssoConnect\DoctrineTypesBundle\Doctrine\DBAL\Types\CountryType;
 use AssoConnect\DoctrineTypesBundle\Tests\TypeTestCase;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class CountryTypeTest extends TypeTestCase
 {
@@ -16,16 +17,18 @@ class CountryTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(CountryType::NAME, $this->type->getName());
+        self::assertSame(CountryType::NAME, (new CountryType())->getName());
     }
 
     public function testGetSQLDeclaration(): void
     {
-        $this->abstractPlatform
-            ->method('getVarcharTypeDeclarationSQL')
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform
+            ->expects(self::once())
+            ->method('getStringTypeDeclarationSQL')
             ->with(['fixed' => true, 'length' => CountryType::LENGTH])
             ->willReturn('VARCHAR');
 
-        self::assertSame('VARCHAR', $this->type->getSQLDeclaration([], $this->abstractPlatform));
+        self::assertSame('VARCHAR', $this->type->getSQLDeclaration([], $platform));
     }
 }

--- a/tests/Doctrine/DBAL/Types/CurrencyTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/CurrencyTypeTest.php
@@ -17,7 +17,7 @@ class CurrencyTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(CurrencyType::NAME, $this->type->getName());
+        self::assertSame(CurrencyType::NAME, (new CurrencyType())->getName());
     }
 
     public function testConvertToDatabaseValueValid(): void

--- a/tests/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsTypeTest.php
@@ -7,7 +7,6 @@ namespace AssoConnect\DoctrineTypesBundle\Tests\Doctrine\DBAL\Types;
 use AssoConnect\DoctrineTypesBundle\Doctrine\DBAL\Types\DateTimeImmutableMicroSecondsType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
-use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
@@ -16,12 +15,23 @@ class DateTimeImmutableMicroSecondsTypeTest extends TestCase
 {
     protected AbstractPlatform&Stub $platform;
 
-    protected Type $type;
+    protected DateTimeImmutableMicroSecondsType $type;
 
     protected function setUp(): void
     {
         $this->type = new DateTimeImmutableMicroSecondsType();
         $this->platform = self::createStub(AbstractPlatform::class);
+    }
+
+    public function testGetName(): void
+    {
+        self::assertSame(DateTimeImmutableMicroSecondsType::NAME, $this->type->getName());
+    }
+
+    public function testGetSQLDeclaration(): void
+    {
+        self::assertSame('DATETIME(3)', $this->type->getSQLDeclaration([], $this->platform));
+        self::assertSame('TIMESTAMP', $this->type->getSQLDeclaration(['version' => true], $this->platform));
     }
 
     /**
@@ -57,6 +67,19 @@ class DateTimeImmutableMicroSecondsTypeTest extends TestCase
     public function testNullConversion(): void
     {
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testNullConversionToDatabaseValue(): void
+    {
+        self::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testConvertFormattedStringToPHPValue(): void
+    {
+        $date = $this->type->convertToPHPValue('1985-09-01 10:11:12.123', $this->platform);
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $date);
+        self::assertSame('1985-09-01 10:11:12.123', $date->format('Y-m-d H:i:s.v'));
     }
 
     #[DataProvider('provideDateTimeValues')]
@@ -108,6 +131,7 @@ class DateTimeImmutableMicroSecondsTypeTest extends TestCase
     {
         $date = $this->type->convertToPHPValue('1985-09-01', $this->platform);
 
+        self::assertInstanceOf(\DateTimeImmutable::class, $date);
         self::assertEquals('00:00:00.000', $date->format('H:i:s.v'));
     }
 
@@ -116,9 +140,11 @@ class DateTimeImmutableMicroSecondsTypeTest extends TestCase
         date_default_timezone_set('Europe/Berlin');
 
         $date = $this->type->convertToPHPValue('2009-08-01', $this->platform);
+        self::assertInstanceOf(\DateTimeImmutable::class, $date);
         self::assertEquals('2009-08-01 00:00:00.000', $date->format('Y-m-d H:i:s.v'));
 
         $date = $this->type->convertToPHPValue('2009-11-01', $this->platform);
+        self::assertInstanceOf(\DateTimeImmutable::class, $date);
         self::assertEquals('2009-11-01 00:00:00.000', $date->format('Y-m-d H:i:s.v'));
     }
 

--- a/tests/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/DateTimeImmutableMicroSecondsTypeTest.php
@@ -8,27 +8,26 @@ use AssoConnect\DoctrineTypesBundle\Doctrine\DBAL\Types\DateTimeImmutableMicroSe
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 class DateTimeImmutableMicroSecondsTypeTest extends TestCase
 {
-    /** @var AbstractPlatform|MockObject */
-    protected AbstractPlatform $platform;
+    protected AbstractPlatform&Stub $platform;
 
     protected Type $type;
 
     protected function setUp(): void
     {
         $this->type = new DateTimeImmutableMicroSecondsType();
-        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
     }
 
     /**
      * @param mixed $value
-     *
-     * @dataProvider invalidPHPValuesProvider
      */
+    #[DataProvider('invalidPHPValuesProvider')]
     public function testInvalidTypeConversionToDatabaseValue($value): void
     {
         $this->expectException(ConversionException::class);
@@ -60,9 +59,7 @@ class DateTimeImmutableMicroSecondsTypeTest extends TestCase
         self::assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
-    /**
-     * @dataProvider provideDateTimeValues
-     */
+    #[DataProvider('provideDateTimeValues')]
     public function testDateConvertsToDatabaseValue(string $datetime, string $expectedDatetimeResult): void
     {
         $date = new \DateTimeImmutable($datetime);
@@ -70,14 +67,22 @@ class DateTimeImmutableMicroSecondsTypeTest extends TestCase
         self::assertSame($expectedDatetimeResult, $this->type->convertToDatabaseValue($date, $this->platform));
     }
 
-    /**
-     * @dataProvider provideDateTimeValues
-     */
+    #[DataProvider('provideDateTimes')]
     public function testConvertDateToPHPValue(string $datetime): void
     {
         $date = new \DateTimeImmutable($datetime);
 
         self::assertSame($date, $this->type->convertToPHPValue($date, $this->platform));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideDateTimes(): iterable
+    {
+        foreach (self::provideDateTimeValues() as $key => [$datetime]) {
+            yield $key => [$datetime];
+        }
     }
 
 

--- a/tests/Doctrine/DBAL/Types/EmailTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/EmailTypeTest.php
@@ -16,6 +16,6 @@ class EmailTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(EmailType::NAME, $this->type->getName());
+        self::assertSame(EmailType::NAME, (new EmailType())->getName());
     }
 }

--- a/tests/Doctrine/DBAL/Types/FrenchSiretTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/FrenchSiretTypeTest.php
@@ -16,6 +16,6 @@ class FrenchSiretTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(FrenchSiretType::NAME, $this->type->getName());
+        self::assertSame(FrenchSiretType::NAME, (new FrenchSiretType())->getName());
     }
 }

--- a/tests/Doctrine/DBAL/Types/LastDigitsUsSocialSecurityNumberTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/LastDigitsUsSocialSecurityNumberTypeTest.php
@@ -16,6 +16,9 @@ class LastDigitsUsSocialSecurityNumberTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(LastDigitsUsSocialSecurityNumberType::NAME, $this->type->getName());
+        self::assertSame(
+            LastDigitsUsSocialSecurityNumberType::NAME,
+            (new LastDigitsUsSocialSecurityNumberType())->getName()
+        );
     }
 }

--- a/tests/Doctrine/DBAL/Types/LatitudeTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/LatitudeTypeTest.php
@@ -16,7 +16,7 @@ class LatitudeTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(LatitudeType::NAME, $this->type->getName());
+        self::assertSame(LatitudeType::NAME, (new LatitudeType())->getName());
     }
 
     public function testGetSQLDeclaration(): void

--- a/tests/Doctrine/DBAL/Types/SpanishNifTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/SpanishNifTypeTest.php
@@ -6,6 +6,7 @@ namespace AssoConnect\DoctrineTypesBundle\Tests\Doctrine\DBAL\Types;
 
 use AssoConnect\DoctrineTypesBundle\Doctrine\DBAL\Types\SpanishNifType;
 use AssoConnect\DoctrineTypesBundle\Tests\TypeTestCase;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class SpanishNifTypeTest extends TypeTestCase
 {
@@ -16,16 +17,18 @@ class SpanishNifTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(SpanishNifType::NAME, $this->type->getName());
+        self::assertSame(SpanishNifType::NAME, (new SpanishNifType())->getName());
     }
 
     public function testGetSQLDeclaration(): void
     {
-        $this->abstractPlatform
-            ->method('getVarcharTypeDeclarationSQL')
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform
+            ->expects(self::once())
+            ->method('getStringTypeDeclarationSQL')
             ->with(['length' => SpanishNifType::LENGTH])
             ->willReturn('VARCHAR');
 
-        self::assertSame('VARCHAR', $this->type->getSQLDeclaration([], $this->abstractPlatform));
+        self::assertSame('VARCHAR', $this->type->getSQLDeclaration([], $platform));
     }
 }

--- a/tests/Doctrine/DBAL/Types/UsSocialSecurityNumberTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/UsSocialSecurityNumberTypeTest.php
@@ -16,6 +16,6 @@ class UsSocialSecurityNumberTypeTest extends TypeTestCase
 
     public function testGetName(): void
     {
-        self::assertSame(UsSocialSecurityNumberType::NAME, $this->type->getName());
+        self::assertSame(UsSocialSecurityNumberType::NAME, (new UsSocialSecurityNumberType())->getName());
     }
 }

--- a/tests/TypeTestCase.php
+++ b/tests/TypeTestCase.php
@@ -6,15 +6,12 @@ namespace AssoConnect\DoctrineTypesBundle\Tests;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 abstract class TypeTestCase extends TestCase
 {
-    /**
-     * @var MockObject|AbstractPlatform
-     */
-    protected $abstractPlatform;
+    protected AbstractPlatform&Stub $abstractPlatform;
 
     protected Type $type;
 
@@ -25,15 +22,7 @@ abstract class TypeTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->abstractPlatform = $this->getMockForAbstractClass(
-            AbstractPlatform::class,
-            array(),
-            '',
-            true,
-            true,
-            true,
-            array('getVarcharTypeDeclarationSQL', 'getDecimalTypeDeclarationSQL')
-        );
+        $this->abstractPlatform = self::createStub(AbstractPlatform::class);
 
         $class = $this->getClass();
         $name = $class::NAME;


### PR DESCRIPTION
- doctrine/dbal constraint: ^2.8|^3.0 -> ^3.6|^4.0 (CI lowest/highest now covers both majors)
- ramsey/uuid-doctrine: ^1.4 -> ^1.4|^2.0
- AbstractFixedLengthStringType: getVarcharTypeDeclarationSQL() -> getStringTypeDeclarationSQL() (removed in DBAL 4, available since 3.4)
- DateTimeImmutableMicroSecondsType: ConversionException static factories are DBAL 3 only; use Types\Exception\{InvalidFormat,InvalidType} when available (DBAL 4)
- getName() and requiresSQLCommentHint() overrides kept while DBAL 3 is supported
- Tests: replace removed getMockForAbstractClass() with createStub/createMock, @dataProvider annotations -> attributes (PHPUnit 13), drop unused doctrine/cache + doctrine/annotations dev deps